### PR TITLE
Feature and cleanup of all sorts

### DIFF
--- a/Beskar.Networking.Abstractions/Extensions/DisposableExtensions.cs
+++ b/Beskar.Networking.Abstractions/Extensions/DisposableExtensions.cs
@@ -1,0 +1,51 @@
+
+namespace Beskar.Networking.Abstractions.Extensions;
+
+/// <summary>
+/// Provides extension methods for disposing collections of disposable objects.
+/// </summary>
+public static class DisposableExtensions
+{
+   /// <param name="disposables">The collection of items to dispose.</param>
+   /// <typeparam name="T">The type of items in the collection.</typeparam>
+   extension<T>(IEnumerable<T>? disposables)
+   {
+      /// <summary>
+      /// Asynchronously disposes all items in the collection that implement <see cref="IAsyncDisposable"/> or <see cref="IDisposable"/>.
+      /// </summary>
+      /// <returns>A <see cref="ValueTask"/> representing the asynchronous operation.</returns>
+      public async ValueTask DisposeAllAsync()
+      {
+         if (disposables is null)
+         {
+            return;
+         }
+
+         foreach (var item in disposables)
+         {
+            if (item is IAsyncDisposable asyncDisposable)
+            {
+               try
+               {
+                  await asyncDisposable.DisposeAsync();
+               }
+               catch
+               {
+                  // Ignored to ensure all elements are attempted to be disposed
+               }
+            }
+            else if (item is IDisposable disposable)
+            {
+               try
+               {
+                  disposable.Dispose();
+               }
+               catch
+               {
+                  // Ignored to ensure all elements are attempted to be disposed
+               }
+            }
+         }
+      }
+   }
+}

--- a/Beskar.Networking.Abstractions/Telemetry/TransportMetrics.cs
+++ b/Beskar.Networking.Abstractions/Telemetry/TransportMetrics.cs
@@ -114,6 +114,62 @@ public static class TransportMetrics
       "{block}",
       "Current count of active rented memory pool blocks.");
 
+    /// <summary>
+    /// Current count of active listeners.
+    /// </summary>
+    public static readonly UpDownCounter<long> ListenersActive = Meter.CreateUpDownCounter<long>(
+       "beskar.transport.listeners.active",
+       "{listener}",
+       "Current count of active bound listener sockets.");
+
+    /// <summary>
+    /// Total failed connection or accept attempts.
+    /// </summary>
+    public static readonly Counter<long> ConnectionsFailed = Meter.CreateCounter<long>(
+       "beskar.transport.connections.failed",
+       "{connection}",
+       "Total failed connection or accept attempts.");
+
+    /// <summary>
+    /// Duration of TLS handshakes.
+    /// </summary>
+    public static readonly Histogram<double> TlsHandshakeDuration = Meter.CreateHistogram<double>(
+       "beskar.transport.tls.handshake.duration",
+       "ms",
+       "Duration of TLS handshakes.");
+
+    /// <summary>
+    /// Total failed TLS handshakes.
+    /// </summary>
+    public static readonly Counter<long> TlsHandshakeFailures = Meter.CreateCounter<long>(
+       "beskar.transport.tls.handshake.failures",
+       "{failure}",
+       "Total failed TLS handshakes.");
+
+    /// <summary>
+    /// Duration of WebSocket upgrade handshakes.
+    /// </summary>
+    public static readonly Histogram<double> WsHandshakeDuration = Meter.CreateHistogram<double>(
+       "beskar.transport.ws.handshake.duration",
+       "ms",
+       "Duration of WebSocket upgrade handshakes.");
+
+    /// <summary>
+    /// Total failed WebSocket upgrade handshakes.
+    /// </summary>
+    public static readonly Counter<long> WsHandshakeFailures = Meter.CreateCounter<long>(
+       "beskar.transport.ws.handshake.failures",
+       "{failure}",
+       "Total failed WebSocket upgrade handshakes.");
+
+    /// <summary>
+    /// Total number of UDP packets dropped due to full pipeline buffer.
+    /// </summary>
+    public static readonly Counter<long> UdpPacketsDropped = Meter.CreateCounter<long>(
+       "beskar.transport.udp.packets.dropped",
+       "{packet}",
+       "Total number of UDP packets dropped due to full pipeline buffer.");
+
    private static readonly KeyValuePair<string, object?>[][] TransportTags = [
       [new KeyValuePair<string, object?>("transport", "unknown")],
       [new KeyValuePair<string, object?>("transport", "tcp")],
@@ -232,6 +288,73 @@ public static class TransportMetrics
       if (MemoryPoolBlocksActive.Enabled)
       {
          MemoryPoolBlocksActive.Add(-1);
+      }
+   }
+
+   public static void RecordListenerStarted(TransportKind kind)
+   {
+      if (ListenersActive.Enabled)
+      {
+         ListenersActive.Add(1, GetTransportTags(kind));
+      }
+   }
+
+   public static void RecordListenerStopped(TransportKind kind)
+   {
+      if (ListenersActive.Enabled)
+      {
+         ListenersActive.Add(-1, GetTransportTags(kind));
+      }
+   }
+
+   public static void RecordConnectionFailed(TransportKind kind, string failureReason)
+   {
+      if (ConnectionsFailed.Enabled)
+      {
+         var tags = GetTransportTags(kind);
+         ConnectionsFailed.Add(1,
+            tags[0],
+            new KeyValuePair<string, object?>("failure", failureReason));
+      }
+   }
+
+   public static void RecordTlsHandshakeDuration(double milliseconds)
+   {
+      if (TlsHandshakeDuration.Enabled)
+      {
+         TlsHandshakeDuration.Record(milliseconds);
+      }
+   }
+
+   public static void RecordTlsHandshakeFailure(string failureReason)
+   {
+      if (TlsHandshakeFailures.Enabled)
+      {
+         TlsHandshakeFailures.Add(1, new KeyValuePair<string, object?>("failure", failureReason));
+      }
+   }
+
+   public static void RecordWsHandshakeDuration(double milliseconds)
+   {
+      if (WsHandshakeDuration.Enabled)
+      {
+         WsHandshakeDuration.Record(milliseconds);
+      }
+   }
+
+   public static void RecordWsHandshakeFailure(string failureReason)
+   {
+      if (WsHandshakeFailures.Enabled)
+      {
+         WsHandshakeFailures.Add(1, new KeyValuePair<string, object?>("failure", failureReason));
+      }
+   }
+
+   public static void RecordUdpPacketDropped()
+   {
+      if (UdpPacketsDropped.Enabled)
+      {
+         UdpPacketsDropped.Add(1);
       }
    }
 }

--- a/Beskar.Networking.Transports.Memory/MemoryNetworkListener.cs
+++ b/Beskar.Networking.Transports.Memory/MemoryNetworkListener.cs
@@ -6,6 +6,7 @@ using Beskar.Networking.Abstractions.Interfaces;
 using Beskar.Networking.Abstractions.Models;
 using Beskar.Utilities.Tracing;
 using Beskar.Memory.Results;
+using Beskar.Networking.Abstractions.Telemetry;
 
 namespace Beskar.Networking.Transports.Memory;
 
@@ -63,6 +64,7 @@ public sealed class MemoryNetworkListener(
 
       _isBound = true;
       Interlocked.Increment(ref _binds);
+      TransportMetrics.RecordListenerStarted(TransportKind.Memory);
       TraceLogger.LogServerInfo("Memory Listener: Successfully bound and listening on {0}", LocalAddress);
 
       return new ValueTask<VoidResult<NetworkCodeError>>(true);
@@ -77,6 +79,7 @@ public sealed class MemoryNetworkListener(
 
       TraceLogger.LogServerInfo("Memory Listener: Unbinding and stopping listener on {0}", LocalAddress);
       _isBound = false;
+      TransportMetrics.RecordListenerStopped(TransportKind.Memory);
       MemoryTransportRegistry.TryUnregister(_configuredLocalAddress.Address, this);
 
       var channel = _sessionChannel;

--- a/Beskar.Networking.Transports.Memory/MemoryNetworkSession.cs
+++ b/Beskar.Networking.Transports.Memory/MemoryNetworkSession.cs
@@ -73,6 +73,11 @@ public sealed class MemoryNetworkSession : INetworkSession
    public ValueTask<Result<INetworkStream, NetworkCodeError>> AcceptStreamAsync(
       CancellationToken ct = default)
    {
+      if (Volatile.Read(ref _disposed) == 1)
+      {
+         throw new ObjectDisposedException(nameof(MemoryNetworkSession));
+      }
+
       if (_stream is null)
       {
          TraceLogger.LogServerInfo("Memory Session {0}: Instantiating bidirectional stream wrapper", Id);
@@ -87,6 +92,11 @@ public sealed class MemoryNetworkSession : INetworkSession
       NetworkStreamDirection direction = NetworkStreamDirection.Bidirectional,
       CancellationToken ct = default)
    {
+      if (Volatile.Read(ref _disposed) == 1)
+      {
+         throw new ObjectDisposedException(nameof(MemoryNetworkSession));
+      }
+
       if (_stream is null)
       {
          TraceLogger.LogClientInfo("Memory Session {0}: Opening bidirectional stream", Id);

--- a/Beskar.Networking.Transports.NamedPipes/NamedPipeNetworkListener.cs
+++ b/Beskar.Networking.Transports.NamedPipes/NamedPipeNetworkListener.cs
@@ -8,6 +8,7 @@ using Beskar.Networking.Abstractions.Models;
 using Beskar.Utilities.Tracing;
 using Beskar.Memory.Results;
 using Beskar.Networking.Abstractions.Enums;
+using Beskar.Networking.Abstractions.Telemetry;
 
 namespace Beskar.Networking.Transports.NamedPipes;
 
@@ -78,6 +79,7 @@ public sealed class NamedPipeNetworkListener(
          _ = AcceptLoopAsync(namedPipeEndPoint, _acceptCts.Token);
          TraceLogger.LogServerInfo("NamedPipe Listener: Successfully bound and waiting for connections on {0}", namedPipeEndPoint);
          Interlocked.Increment(ref _binds);
+         TransportMetrics.RecordListenerStarted(TransportKind.NamedPipe);
 
          return new ValueTask<VoidResult<NetworkCodeError>>(true);
       }
@@ -115,6 +117,7 @@ public sealed class NamedPipeNetworkListener(
 
          TraceLogger.LogServerInfo("NamedPipe Listener: Successfully unbound");
          Interlocked.Increment(ref _unbinds);
+         TransportMetrics.RecordListenerStopped(TransportKind.NamedPipe);
 
          return true;
       }

--- a/Beskar.Networking.Transports.NamedPipes/NamedPipeNetworkSession.cs
+++ b/Beskar.Networking.Transports.NamedPipes/NamedPipeNetworkSession.cs
@@ -71,6 +71,11 @@ public sealed class NamedPipeNetworkSession : INetworkSession
    public ValueTask<Result<INetworkStream, NetworkCodeError>> AcceptStreamAsync(
       CancellationToken ct = default)
    {
+      if (Volatile.Read(ref _disposed) == 1)
+      {
+         throw new ObjectDisposedException(nameof(NamedPipeNetworkSession));
+      }
+
       if (_stream is null)
       {
          TraceLogger.LogServerInfo("NamedPipe Session {0}: Instantiating Named Pipe stream wrapper", Id);
@@ -85,6 +90,11 @@ public sealed class NamedPipeNetworkSession : INetworkSession
       NetworkStreamDirection direction = NetworkStreamDirection.Bidirectional,
       CancellationToken ct = default)
    {
+      if (Volatile.Read(ref _disposed) == 1)
+      {
+         throw new ObjectDisposedException(nameof(NamedPipeNetworkSession));
+      }
+
       if (_stream is null)
       {
          TraceLogger.LogClientInfo("NamedPipe Session {0}: Opening Named Pipe stream connection", Id);

--- a/Beskar.Networking.Transports.Quic/QuicNetworkClient.cs
+++ b/Beskar.Networking.Transports.Quic/QuicNetworkClient.cs
@@ -8,6 +8,7 @@ using Beskar.Networking.Abstractions.Models;
 using Beskar.Utilities.Tracing;
 using Beskar.Memory.Results;
 using Beskar.Networking.Abstractions.Enums;
+using Beskar.Networking.Abstractions.Telemetry;
 
 namespace Beskar.Networking.Transports.Quic;
 
@@ -118,11 +119,13 @@ public sealed class QuicNetworkClient : INetworkClient
       }
       catch (QuicException ex)
       {
+         TransportMetrics.RecordConnectionFailed(TransportKind.Quic, ex.QuicError.ToString());
          TraceLogger.LogClientError("QUIC ConnectAsync: QUIC exception connecting to {0} (Code: {1}): {2}", endPoint, (int)ex.QuicError, ex.Message);
          return new NetworkCodeError((int)ex.QuicError, ex.Message);
       }
       catch (Exception ex)
       {
+         TransportMetrics.RecordConnectionFailed(TransportKind.Quic, ex.GetType().Name);
          TraceLogger.LogClientError("QUIC ConnectAsync: Unexpected exception connecting to {0}: {1}", endPoint, ex.Message);
          return new NetworkCodeError(-1, ex.Message);
       }

--- a/Beskar.Networking.Transports.Quic/QuicNetworkListener.cs
+++ b/Beskar.Networking.Transports.Quic/QuicNetworkListener.cs
@@ -9,6 +9,7 @@ using Beskar.Networking.Abstractions.Models;
 using Beskar.Utilities.Tracing;
 using Beskar.Memory.Results;
 using Beskar.Networking.Abstractions.Enums;
+using Beskar.Networking.Abstractions.Telemetry;
 
 namespace Beskar.Networking.Transports.Quic;
 
@@ -115,7 +116,9 @@ public sealed class QuicNetworkListener(
 
          _ = AcceptLoopAsync(_listener, _acceptCts.Token);
          TraceLogger.LogServerInfo("QUIC Listener: Successfully bound and listening on {0}", LocalAddress);
+
          Interlocked.Increment(ref _binds);
+         TransportMetrics.RecordListenerStarted(TransportKind.Quic);
          return true;
       }
       catch (QuicException ex)
@@ -148,6 +151,7 @@ public sealed class QuicNetworkListener(
          if (listener is not null)
          {
             await listener.DisposeAsync();
+            TransportMetrics.RecordListenerStopped(TransportKind.Quic);
          }
 
          _sessionChannel.Writer.TryComplete();
@@ -219,6 +223,8 @@ public sealed class QuicNetworkListener(
             {
                break;
             }
+
+            TransportMetrics.RecordConnectionFailed(TransportKind.Quic, ex.QuicError.ToString());
             TraceLogger.LogServerError("QUIC Listener: QuicException accepting connection (Code: {0}): {1}", (int)ex.QuicError, ex.Message);
             WriteToSessionChannel(new NetworkCodeError((int)ex.QuicError, $"Listener acceptance error: {ex.Message}"));
 
@@ -230,6 +236,8 @@ public sealed class QuicNetworkListener(
             {
                break;
             }
+
+            TransportMetrics.RecordConnectionFailed(TransportKind.Quic, ex.GetType().Name);
             TraceLogger.LogServerError("QUIC Listener: Unexpected error accepting connection: {0}", ex.Message);
             WriteToSessionChannel(new NetworkCodeError(-1, $"Listener acceptance error: {ex.Message}"));
 

--- a/Beskar.Networking.Transports.Quic/QuicNetworkSession.cs
+++ b/Beskar.Networking.Transports.Quic/QuicNetworkSession.cs
@@ -9,6 +9,7 @@ using Beskar.Networking.Abstractions.Telemetry;
 using Beskar.Networking.Transports.Common.Streams;
 using Beskar.Utilities.Tracing;
 using Beskar.Memory.Results;
+using Beskar.Networking.Abstractions.Extensions;
 
 namespace Beskar.Networking.Transports.Quic;
 
@@ -315,17 +316,7 @@ public sealed class QuicNetworkSession : INetworkSession
          // Ignored
       }
 
-      foreach (var stream in _activeStreams.Values)
-      {
-         try
-         {
-            await stream.DisposeAsync();
-         }
-         catch
-         {
-            // Ignored
-         }
-      }
+      await _activeStreams.Values.DisposeAllAsync();
       _activeStreams.Clear();
 
       try

--- a/Beskar.Networking.Transports.Quic/QuicNetworkSession.cs
+++ b/Beskar.Networking.Transports.Quic/QuicNetworkSession.cs
@@ -126,6 +126,11 @@ public sealed class QuicNetworkSession : INetworkSession
 
    public async ValueTask<Result<INetworkStream, NetworkCodeError>> AcceptStreamAsync(CancellationToken ct = default)
    {
+      if (Volatile.Read(ref _disposed) == 1)
+      {
+         throw new ObjectDisposedException(nameof(QuicNetworkSession));
+      }
+
       QuicStream? quicStream = null;
       StreamConnection? connection = null;
       var success = false;
@@ -194,6 +199,11 @@ public sealed class QuicNetworkSession : INetworkSession
       NetworkStreamDirection direction = NetworkStreamDirection.Bidirectional,
       CancellationToken ct = default)
    {
+      if (Volatile.Read(ref _disposed) == 1)
+      {
+         throw new ObjectDisposedException(nameof(QuicNetworkSession));
+      }
+
       QuicStream? quicStream = null;
       StreamConnection? connection = null;
       var success = false;

--- a/Beskar.Networking.Transports.Tcp/TcpNetworkClient.cs
+++ b/Beskar.Networking.Transports.Tcp/TcpNetworkClient.cs
@@ -52,22 +52,7 @@ public sealed class TcpNetworkClient(TcpTransportOptions options)
          TraceLogger.LogClientInfo("TCP ConnectAsync: Initiating socket connection to {0}", endPoint);
          socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
 
-         if (_options.NoDelay)
-         {
-            socket.NoDelay = true;
-         }
-         if (_options.SendBufferSize.HasValue)
-         {
-            socket.SendBufferSize = _options.SendBufferSize.Value;
-         }
-         if (_options.ReceiveBufferSize.HasValue)
-         {
-            socket.ReceiveBufferSize = _options.ReceiveBufferSize.Value;
-         }
-         if (_options.LingerState is not null)
-         {
-            socket.LingerState = _options.LingerState;
-         }
+         _options.ConfigureSocket(socket);
 
          await socket.ConnectAsync(endPoint, ct);
          TraceLogger.LogClientInfo("TCP ConnectAsync: Socket successfully connected to {0} (Local: {1})", socket.RemoteEndPoint, socket.LocalEndPoint);

--- a/Beskar.Networking.Transports.Tcp/TcpNetworkClient.cs
+++ b/Beskar.Networking.Transports.Tcp/TcpNetworkClient.cs
@@ -9,6 +9,8 @@ using Beskar.Networking.Abstractions.Models;
 using Beskar.Utilities.Tracing;
 using Beskar.Memory.Results;
 using Beskar.Networking.Abstractions.Enums;
+using System.Diagnostics;
+using Beskar.Networking.Abstractions.Telemetry;
 
 namespace Beskar.Networking.Transports.Tcp;
 
@@ -74,7 +76,17 @@ public sealed class TcpNetworkClient(TcpTransportOptions options)
             using var handshakeTimeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             handshakeTimeoutCts.CancelAfter(_options.SslHandshakeTimeout);
 
-            await sslStream.AuthenticateAsClientAsync(sslOptions, handshakeTimeoutCts.Token);
+            var start = Stopwatch.GetTimestamp();
+            try
+            {
+               await sslStream.AuthenticateAsClientAsync(sslOptions, handshakeTimeoutCts.Token);
+               TransportMetrics.RecordTlsHandshakeDuration(Stopwatch.GetElapsedTime(start).TotalMilliseconds);
+            }
+            catch (Exception ex)
+            {
+               TransportMetrics.RecordTlsHandshakeFailure(ex.Message);
+               throw;
+            }
             stream = sslStream;
             TraceLogger.LogClientInfo("TCP ConnectAsync: SSL client successfully authenticated for {0}", endPoint);
          }
@@ -104,6 +116,7 @@ public sealed class TcpNetworkClient(TcpTransportOptions options)
       }
       catch (SocketException ex)
       {
+         TransportMetrics.RecordConnectionFailed(TransportKind.Tcp, ex.SocketErrorCode.ToString());
          if (connection is not null)
          {
             await _ioQueueRegistry.ReturnAsync(connection);
@@ -122,6 +135,7 @@ public sealed class TcpNetworkClient(TcpTransportOptions options)
       }
       catch (Exception ex)
       {
+         TransportMetrics.RecordConnectionFailed(TransportKind.Tcp, ex.GetType().Name);
          if (connection is not null)
          {
             await _ioQueueRegistry.ReturnAsync(connection);

--- a/Beskar.Networking.Transports.Tcp/TcpNetworkListener.cs
+++ b/Beskar.Networking.Transports.Tcp/TcpNetworkListener.cs
@@ -297,6 +297,19 @@ public sealed class TcpNetworkListener(
                return;
             }
 
+            if (_options.ClientCertificateRequired.HasValue)
+            {
+               sslOptions.ClientCertificateRequired = _options.ClientCertificateRequired.Value;
+            }
+            if (_options.ClientCertificateValidationCallback is not null)
+            {
+               sslOptions.RemoteCertificateValidationCallback = _options.ClientCertificateValidationCallback;
+            }
+            if (_options.ClientCertificateRevocationMode.HasValue)
+            {
+               sslOptions.CertificateRevocationCheckMode = _options.ClientCertificateRevocationMode.Value;
+            }
+
             await sslStream.AuthenticateAsServerAsync(sslOptions, handshakeTimeoutCts.Token);
             stream = sslStream;
 

--- a/Beskar.Networking.Transports.Tcp/TcpNetworkListener.cs
+++ b/Beskar.Networking.Transports.Tcp/TcpNetworkListener.cs
@@ -9,6 +9,8 @@ using Beskar.Networking.Abstractions.Models;
 using Beskar.Utilities.Tracing;
 using Beskar.Memory.Results;
 using Beskar.Networking.Abstractions.Enums;
+using System.Diagnostics;
+using Beskar.Networking.Abstractions.Telemetry;
 
 namespace Beskar.Networking.Transports.Tcp;
 
@@ -80,7 +82,9 @@ public sealed class TcpNetworkListener(
 
          _ = AcceptLoopAsync(socket, _acceptCts.Token);
          TraceLogger.LogServerInfo("TCP Listener: Successfully bound and listening on {0}", LocalAddress);
+
          Interlocked.Increment(ref _binds);
+         TransportMetrics.RecordListenerStarted(TransportKind.Tcp);
 
          return new ValueTask<VoidResult<NetworkCodeError>>(true);
       }
@@ -127,6 +131,7 @@ public sealed class TcpNetworkListener(
 
          TraceLogger.LogServerInfo("TCP Listener: Successfully unbound from {0}", LocalAddress);
          Interlocked.Increment(ref _unbinds);
+         TransportMetrics.RecordListenerStopped(TransportKind.Tcp);
 
          return true;
       }
@@ -201,6 +206,7 @@ public sealed class TcpNetworkListener(
                {
                   TraceLogger.LogServerError("TCP Listener: Rejected connection. Failed to get remote endpoint.");
                   WriteToSessionChannel(new NetworkCodeError(-1, "Failed to get remote endpoint."));
+                  TransportMetrics.RecordConnectionFailed(TransportKind.Tcp, "NoRemoteEndPoint");
 
                   clientSocket.Dispose();
                   semaphore.Release();
@@ -246,6 +252,7 @@ public sealed class TcpNetworkListener(
                break;
             }
 
+            TransportMetrics.RecordConnectionFailed(TransportKind.Tcp, ex.SocketErrorCode.ToString());
             TraceLogger.LogServerError("TCP Listener: Socket error accepting client: {0}", ex.Message);
             WriteToSessionChannel(new NetworkCodeError(ex.ErrorCode, $"Listener acceptance error: {ex.Message}"));
 
@@ -258,6 +265,7 @@ public sealed class TcpNetworkListener(
                break;
             }
 
+            TransportMetrics.RecordConnectionFailed(TransportKind.Tcp, ex.GetType().Name);
             TraceLogger.LogServerError("TCP Listener: Unexpected error accepting client: {0}", ex.Message);
             WriteToSessionChannel(new NetworkCodeError(-1, $"Listener acceptance error: {ex.Message}"));
 
@@ -310,7 +318,17 @@ public sealed class TcpNetworkListener(
                sslOptions.CertificateRevocationCheckMode = _options.ClientCertificateRevocationMode.Value;
             }
 
-            await sslStream.AuthenticateAsServerAsync(sslOptions, handshakeTimeoutCts.Token);
+            var start = Stopwatch.GetTimestamp();
+            try
+            {
+               await sslStream.AuthenticateAsServerAsync(sslOptions, handshakeTimeoutCts.Token);
+               TransportMetrics.RecordTlsHandshakeDuration(Stopwatch.GetElapsedTime(start).TotalMilliseconds);
+            }
+            catch (Exception ex)
+            {
+               TransportMetrics.RecordTlsHandshakeFailure(ex.Message);
+               throw;
+            }
             stream = sslStream;
 
             TraceLogger.LogServerInfo("TCP Listener: SSL server successfully authenticated client {0}", remoteEndPoint);
@@ -337,11 +355,13 @@ public sealed class TcpNetworkListener(
       {
          TraceLogger.LogServerError("TCP Listener: Socket error during handshake for client {0}: {1}", remoteEndPoint, ex.Message);
          WriteToSessionChannel(new NetworkCodeError(ex.ErrorCode, ex.Message));
+         TransportMetrics.RecordConnectionFailed(TransportKind.Tcp, ex.SocketErrorCode.ToString());
       }
       catch (Exception ex)
       {
          TraceLogger.LogServerError("TCP Listener: Unexpected error during handshake for client {0}: {1}", remoteEndPoint, ex.Message);
          WriteToSessionChannel(new NetworkCodeError(-1, ex.Message));
+         TransportMetrics.RecordConnectionFailed(TransportKind.Tcp, ex.GetType().Name);
       }
       finally
       {

--- a/Beskar.Networking.Transports.Tcp/TcpNetworkListener.cs
+++ b/Beskar.Networking.Transports.Tcp/TcpNetworkListener.cs
@@ -183,22 +183,7 @@ public sealed class TcpNetworkListener(
 
             try
             {
-               if (_options.NoDelay)
-               {
-                  clientSocket.NoDelay = true;
-               }
-               if (_options.SendBufferSize.HasValue)
-               {
-                  clientSocket.SendBufferSize = _options.SendBufferSize.Value;
-               }
-               if (_options.ReceiveBufferSize.HasValue)
-               {
-                  clientSocket.ReceiveBufferSize = _options.ReceiveBufferSize.Value;
-               }
-               if (_options.LingerState is not null)
-               {
-                  clientSocket.LingerState = _options.LingerState;
-               }
+               _options.ConfigureSocket(clientSocket);
 
                var localEndPoint = clientSocket.LocalEndPoint;
                if (localEndPoint is null)

--- a/Beskar.Networking.Transports.Tcp/TcpNetworkSession.cs
+++ b/Beskar.Networking.Transports.Tcp/TcpNetworkSession.cs
@@ -95,6 +95,11 @@ public sealed class TcpNetworkSession : INetworkSession
    public ValueTask<Result<INetworkStream, NetworkCodeError>> AcceptStreamAsync(
       CancellationToken ct = default)
    {
+      if (Volatile.Read(ref _disposed) == 1)
+      {
+         throw new ObjectDisposedException(nameof(TcpNetworkSession));
+      }
+
       if (_stream is null)
       {
          TraceLogger.LogServerInfo("TCP Session {0}: Instantiating bidirectional TCP stream wrapper", Id);
@@ -109,6 +114,11 @@ public sealed class TcpNetworkSession : INetworkSession
       NetworkStreamDirection direction = NetworkStreamDirection.Bidirectional,
       CancellationToken ct = default)
    {
+      if (Volatile.Read(ref _disposed) == 1)
+      {
+         throw new ObjectDisposedException(nameof(TcpNetworkSession));
+      }
+
       if (_stream is null)
       {
          TraceLogger.LogClientInfo("TCP Session {0}: Opening bidirectional TCP stream connection", Id);

--- a/Beskar.Networking.Transports.Tcp/TcpTransportOptions.cs
+++ b/Beskar.Networking.Transports.Tcp/TcpTransportOptions.cs
@@ -1,5 +1,6 @@
 using System.Net.Security;
 using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
 using Beskar.Networking.Transports.Common.Options;
 
 namespace Beskar.Networking.Transports.Tcp;
@@ -122,6 +123,24 @@ public class TcpTransportOptions
    /// Set null to use the OS default.
    /// </summary>
    public int? KeepAliveRetryCount { get; set; }
+
+   /// <summary>
+   /// Whether a client certificate is required for SSL/TLS connections.
+   /// If configured, overrides SslServerOptions.ClientCertificateRequired.
+   /// </summary>
+   public bool? ClientCertificateRequired { get; set; }
+
+   /// <summary>
+   /// A custom callback to validate client certificates.
+   /// If configured, overrides SslServerOptions.RemoteCertificateValidationCallback.
+   /// </summary>
+   public RemoteCertificateValidationCallback? ClientCertificateValidationCallback { get; set; }
+
+   /// <summary>
+   /// The certificate revocation mode for client certificate validation.
+   /// If configured, overrides SslServerOptions.CertificateRevocationMode.
+   /// </summary>
+   public X509RevocationMode? ClientCertificateRevocationMode { get; set; }
 
    /// <summary>
    /// Configures standard TCP socket options on the specified socket.

--- a/Beskar.Networking.Transports.Tcp/TcpTransportOptions.cs
+++ b/Beskar.Networking.Transports.Tcp/TcpTransportOptions.cs
@@ -99,4 +99,71 @@ public class TcpTransportOptions
    /// Defaults to 10 seconds.
    /// </summary>
    public TimeSpan SslHandshakeTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+   /// <summary>
+   /// Whether to enable TCP keep-alive probes. Defaults to false.
+   /// </summary>
+   public bool KeepAlive { get; set; }
+
+   /// <summary>
+   /// The number of seconds a connection will remain idle before the first keep-alive probe is sent.
+   /// Set null to use the OS default.
+   /// </summary>
+   public int? KeepAliveTime { get; set; }
+
+   /// <summary>
+   /// The number of seconds between subsequent keep-alive probes if no acknowledgment is received.
+   /// Set null to use the OS default.
+   /// </summary>
+   public int? KeepAliveInterval { get; set; }
+
+   /// <summary>
+   /// The number of keep-alive probes to send before the connection is declared dead.
+   /// Set null to use the OS default.
+   /// </summary>
+   public int? KeepAliveRetryCount { get; set; }
+
+   /// <summary>
+   /// Configures standard TCP socket options on the specified socket.
+   /// </summary>
+   /// <param name="socket">The socket to configure.</param>
+   public void ConfigureSocket(Socket socket)
+   {
+      if (NoDelay)
+      {
+         socket.NoDelay = true;
+      }
+      if (SendBufferSize.HasValue)
+      {
+         socket.SendBufferSize = SendBufferSize.Value;
+      }
+      if (ReceiveBufferSize.HasValue)
+      {
+         socket.ReceiveBufferSize = ReceiveBufferSize.Value;
+      }
+      if (LingerState is not null)
+      {
+         socket.LingerState = LingerState;
+      }
+
+      if (KeepAlive || KeepAliveTime.HasValue || KeepAliveInterval.HasValue || KeepAliveRetryCount.HasValue)
+      {
+         socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
+
+         if (KeepAliveTime.HasValue)
+         {
+            socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, KeepAliveTime.Value);
+         }
+
+         if (KeepAliveInterval.HasValue)
+         {
+            socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveInterval, KeepAliveInterval.Value);
+         }
+
+         if (KeepAliveRetryCount.HasValue)
+         {
+            socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveRetryCount, KeepAliveRetryCount.Value);
+         }
+      }
+   }
 }

--- a/Beskar.Networking.Transports.Udp/UdpNetworkListener.cs
+++ b/Beskar.Networking.Transports.Udp/UdpNetworkListener.cs
@@ -8,6 +8,7 @@ using Beskar.Networking.Abstractions.Interfaces;
 using Beskar.Networking.Abstractions.Models;
 using Beskar.Utilities.Tracing;
 using Beskar.Memory.Results;
+using Beskar.Networking.Abstractions.Telemetry;
 
 namespace Beskar.Networking.Transports.Udp;
 
@@ -99,6 +100,7 @@ public sealed class UdpNetworkListener(
 
          TraceLogger.LogServerInfo("UDP Listener: Successfully bound and listening on {0}", LocalAddress);
          Interlocked.Increment(ref _binds);
+         TransportMetrics.RecordListenerStarted(TransportKind.Udp);
 
          return new ValueTask<VoidResult<NetworkCodeError>>(true);
       }
@@ -185,6 +187,7 @@ public sealed class UdpNetworkListener(
 
          TraceLogger.LogServerInfo("UDP Listener: Successfully unbound from {0}", LocalAddress);
          Interlocked.Increment(ref _unbinds);
+         TransportMetrics.RecordListenerStopped(TransportKind.Udp);
 
          return true;
       }

--- a/Beskar.Networking.Transports.Udp/UdpNetworkSession.cs
+++ b/Beskar.Networking.Transports.Udp/UdpNetworkSession.cs
@@ -162,6 +162,7 @@ public sealed class UdpNetworkSession : INetworkSession
 
       if (Volatile.Read(ref _isWriterPaused) == 1)
       {
+         TransportMetrics.RecordUdpPacketDropped();
          // Drop packet since the session pipe is full
          return ValueTask.CompletedTask;
       }

--- a/Beskar.Networking.Transports.Udp/UdpNetworkSession.cs
+++ b/Beskar.Networking.Transports.Udp/UdpNetworkSession.cs
@@ -134,6 +134,11 @@ public sealed class UdpNetworkSession : INetworkSession
 
    public ValueTask<Result<INetworkStream, NetworkCodeError>> AcceptStreamAsync(CancellationToken ct = default)
    {
+      if (Volatile.Read(ref _disposed) == 1)
+      {
+         throw new ObjectDisposedException(nameof(UdpNetworkSession));
+      }
+
       Interlocked.Increment(ref _streamsAccepted);
       return new ValueTask<Result<INetworkStream, NetworkCodeError>>(_stream);
    }
@@ -142,6 +147,11 @@ public sealed class UdpNetworkSession : INetworkSession
       NetworkStreamDirection direction = NetworkStreamDirection.Bidirectional,
       CancellationToken ct = default)
    {
+      if (Volatile.Read(ref _disposed) == 1)
+      {
+         throw new ObjectDisposedException(nameof(UdpNetworkSession));
+      }
+
       Interlocked.Increment(ref _streamsOpened);
       return new ValueTask<Result<INetworkStream, NetworkCodeError>>(_stream);
    }

--- a/Beskar.Networking.Transports.Uds/UdsNetworkListener.cs
+++ b/Beskar.Networking.Transports.Uds/UdsNetworkListener.cs
@@ -8,6 +8,7 @@ using Beskar.Networking.Abstractions.Models;
 using Beskar.Utilities.Tracing;
 using Beskar.Memory.Results;
 using Beskar.Networking.Abstractions.Enums;
+using Beskar.Networking.Abstractions.Telemetry;
 
 namespace Beskar.Networking.Transports.Uds;
 
@@ -103,6 +104,7 @@ public sealed class UdsNetworkListener(
          _ = AcceptLoopAsync(socket, _acceptCts.Token);
          TraceLogger.LogServerInfo("UDS Listener: Successfully bound and listening on {0}", socketPath);
          Interlocked.Increment(ref _binds);
+         TransportMetrics.RecordListenerStarted(TransportKind.UnixDomainSocket);
 
          return new ValueTask<VoidResult<NetworkCodeError>>(true);
       }
@@ -165,6 +167,7 @@ public sealed class UdsNetworkListener(
 
          TraceLogger.LogServerInfo("UDS Listener: Successfully unbound");
          Interlocked.Increment(ref _unbinds);
+         TransportMetrics.RecordListenerStopped(TransportKind.UnixDomainSocket);
 
          return true;
       }

--- a/Beskar.Networking.Transports.Uds/UdsNetworkSession.cs
+++ b/Beskar.Networking.Transports.Uds/UdsNetworkSession.cs
@@ -72,6 +72,11 @@ public sealed class UdsNetworkSession : INetworkSession
    public ValueTask<Result<INetworkStream, NetworkCodeError>> AcceptStreamAsync(
       CancellationToken ct = default)
    {
+      if (Volatile.Read(ref _disposed) == 1)
+      {
+         throw new ObjectDisposedException(nameof(UdsNetworkSession));
+      }
+
       if (_stream is null)
       {
          TraceLogger.LogServerInfo("UDS Session {0}: Instantiating UDS stream wrapper", Id);
@@ -86,6 +91,11 @@ public sealed class UdsNetworkSession : INetworkSession
       NetworkStreamDirection direction = NetworkStreamDirection.Bidirectional,
       CancellationToken ct = default)
    {
+      if (Volatile.Read(ref _disposed) == 1)
+      {
+         throw new ObjectDisposedException(nameof(UdsNetworkSession));
+      }
+
       if (_stream is null)
       {
          TraceLogger.LogClientInfo("UDS Session {0}: Opening UDS stream connection", Id);

--- a/Beskar.Networking.Transports.Ws/WsHandshake.cs
+++ b/Beskar.Networking.Transports.Ws/WsHandshake.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Collections.Generic;
 using System.IO.Pipelines;
 using System.Net;
 using System.Security.Cryptography;
@@ -49,7 +50,7 @@ public static class WsHandshake
    /// <summary>
    /// Performs the server-side HTTP/1.1 WebSocket upgrade handshake.
    /// </summary>
-   public static async Task<string?> ServerHandshakeAsync(
+   public static async Task<(string? AcceptKey, Dictionary<string, string>? Headers, Dictionary<string, string>? Cookies)> ServerHandshakeAsync(
       IDuplexPipe tcpPipe,
       WsTransportOptions options,
       CancellationToken ct)
@@ -69,13 +70,13 @@ public static class WsHandshake
       catch (OperationCanceledException)
       {
          TraceLogger.LogServerError("WS Handshake: Failed to read HTTP headers. Handshake timed out.");
-         return null;
+         return (null, null, null);
       }
 
       if (headersText == null)
       {
          TraceLogger.LogServerError("WS Handshake: Failed to read HTTP headers from client or headers exceeded limits.");
-         return null;
+         return (null, null, null);
       }
 
       var lines = headersText.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
@@ -83,7 +84,7 @@ public static class WsHandshake
       {
          TraceLogger.LogServerError("WS Handshake: Server handshake failed: only GET requests are allowed.");
          await SendErrorResponseAsync(writer, "400 Bad Request", "Only GET requests are allowed.");
-         return null;
+         return (null, null, null);
       }
 
       var path = lines[0].Split(' ')[1];
@@ -91,13 +92,16 @@ public static class WsHandshake
       {
          TraceLogger.LogServerError("WS Handshake: Server handshake failed: specified path {0} does not match expected path {1}", path, options.Path);
          await SendErrorResponseAsync(writer, "404 Not Found", "Specified path is not found.");
-         return null;
+         return (null, null, null);
       }
 
       string? clientKey = null;
       var isUpgrade = false;
       var isConnectionUpgrade = false;
       string? origin = null;
+
+      Dictionary<string, string>? requestHeaders = null;
+      Dictionary<string, string>? requestCookies = null;
 
       for (var i = 1; i < lines.Length; i++)
       {
@@ -107,6 +111,12 @@ public static class WsHandshake
 
          var headerName = line[..colonIdx].Trim().ToLowerInvariant();
          var headerValue = line[(colonIdx + 1)..].Trim();
+
+         if (options.GatherHeaders)
+         {
+            requestHeaders ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            requestHeaders[line[..colonIdx].Trim()] = headerValue;
+         }
 
          if (headerName == "upgrade" && headerValue.Equals("websocket", StringComparison.OrdinalIgnoreCase))
          {
@@ -124,6 +134,22 @@ public static class WsHandshake
          {
             origin = headerValue;
          }
+         else if (headerName == "cookie" && options.GatherCookies)
+         {
+            requestCookies ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var cookiePairs = headerValue.Split(';', StringSplitOptions.RemoveEmptyEntries);
+
+            foreach (var pair in cookiePairs)
+            {
+               var eqIdx = pair.IndexOf('=');
+               if (eqIdx != -1)
+               {
+                  var name = pair[..eqIdx].Trim();
+                  var value = pair[(eqIdx + 1)..].Trim();
+                  requestCookies[name] = value;
+               }
+            }
+         }
       }
 
       if (options.AllowedOrigins is not null && options.AllowedOrigins.Length > 0)
@@ -132,7 +158,7 @@ public static class WsHandshake
          {
             TraceLogger.LogServerError("WS Handshake: Server handshake failed: Origin header is missing but AllowedOrigins is configured.");
             await SendErrorResponseAsync(writer, "400 Bad Request", "Origin header is required.");
-            return null;
+            return (null, requestHeaders, requestCookies);
          }
 
          var matched = false;
@@ -149,7 +175,7 @@ public static class WsHandshake
          {
             TraceLogger.LogServerError("WS Handshake: Server handshake failed: origin '{0}' is not allowed.", origin);
             await SendErrorResponseAsync(writer, "403 Forbidden", "Origin is not allowed.");
-            return null;
+            return (null, requestHeaders, requestCookies);
          }
       }
 
@@ -157,13 +183,13 @@ public static class WsHandshake
       {
          TraceLogger.LogServerError("WS Handshake: Server handshake failed: missing, invalid, or too long WebSocket upgrade headers.");
          await SendErrorResponseAsync(writer, "400 Bad Request", "Invalid WebSocket upgrade headers.");
-         return null;
+         return (null, requestHeaders, requestCookies);
       }
 
       // Complete handshake
       var acceptKey = ComputeAcceptKey(clientKey);
       {
-         var response = new TextWriterIndentSlim(stackalloc char[256], stackalloc char[1]);
+         var response = new TextWriterIndentSlim(stackalloc char[512], stackalloc char[1]);
          try
          {
             response.Write("HTTP/1.1 101 Switching Protocols\r\n");
@@ -199,7 +225,7 @@ public static class WsHandshake
       await writer.FlushAsync(ct);
 
       TraceLogger.LogServerInfo("WS Handshake: Server WebSocket upgrade handshake successful (Accept Key: {0})", acceptKey);
-      return acceptKey;
+      return (acceptKey, requestHeaders, requestCookies);
    }
 
    /// <summary>
@@ -224,7 +250,7 @@ public static class WsHandshake
       TraceLogger.LogClientInfo("WS Handshake: Starting client WebSocket handshake with host {0} on path {1}", host, options.Path);
 
       {
-         var request = new TextWriterIndentSlim(stackalloc char[512], stackalloc char[1]);
+         var request = new TextWriterIndentSlim(stackalloc char[1024], stackalloc char[1]);
          try
          {
             request.Write("GET ");
@@ -252,6 +278,36 @@ public static class WsHandshake
                request.Write(options.Origin);
                request.Write("\r\n");
             }
+
+            if (options.Headers is not null)
+            {
+               foreach (var (key, value) in options.Headers)
+               {
+                  request.Write(key);
+                  request.Write(": ");
+                  request.Write(value);
+                  request.Write("\r\n");
+               }
+            }
+
+            if (options.Cookies is not null && options.Cookies.Count > 0)
+            {
+               request.Write("Cookie: ");
+               var first = true;
+               foreach (var (name, value) in options.Cookies)
+               {
+                  if (!first)
+                  {
+                     request.Write("; ");
+                  }
+                  request.Write(name);
+                  request.Write("=");
+                  request.Write(value);
+                  first = false;
+               }
+               request.Write("\r\n");
+            }
+
             request.Write("\r\n");
 
             var writtenSpan = request.WrittenSpan;
@@ -286,6 +342,7 @@ public static class WsHandshake
       }
 
       var serverAcceptKeyMatched = false;
+
       for (var i = 1; i < lines.Length; i++)
       {
          var line = lines[i];

--- a/Beskar.Networking.Transports.Ws/WsHandshake.cs
+++ b/Beskar.Networking.Transports.Ws/WsHandshake.cs
@@ -79,18 +79,48 @@ public static class WsHandshake
          return (null, null, null);
       }
 
-      var lines = headersText.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
-      if (lines.Length == 0 || !lines[0].StartsWith("GET ", StringComparison.OrdinalIgnoreCase))
+      var remaining = headersText.AsSpan();
+
+      // Parse the first line (GET /path HTTP/1.1)
+      var firstLineEnd = remaining.IndexOf("\r\n".AsSpan());
+      ReadOnlySpan<char> firstLine;
+      if (firstLineEnd == -1)
+      {
+         firstLine = remaining;
+         remaining = default;
+      }
+      else
+      {
+         firstLine = remaining[..firstLineEnd];
+         remaining = remaining[(firstLineEnd + 2)..];
+      }
+
+      if (!firstLine.StartsWith("GET ".AsSpan(), StringComparison.OrdinalIgnoreCase))
       {
          TraceLogger.LogServerError("WS Handshake: Server handshake failed: only GET requests are allowed.");
          await SendErrorResponseAsync(writer, "400 Bad Request", "Only GET requests are allowed.");
          return (null, null, null);
       }
 
-      var path = lines[0].Split(' ')[1];
-      if (path != options.Path)
+      var firstSpace = firstLine.IndexOf(' ');
+      if (firstSpace == -1)
       {
-         TraceLogger.LogServerError("WS Handshake: Server handshake failed: specified path {0} does not match expected path {1}", path, options.Path);
+         TraceLogger.LogServerError("WS Handshake: Server handshake failed: invalid GET request format.");
+         return (null, null, null);
+      }
+
+      var afterGet = firstLine[(firstSpace + 1)..];
+      var secondSpace = afterGet.IndexOf(' ');
+      if (secondSpace == -1)
+      {
+         TraceLogger.LogServerError("WS Handshake: Server handshake failed: invalid GET request format.");
+         return (null, null, null);
+      }
+
+      var pathSpan = afterGet[..secondSpace];
+      if (!pathSpan.Equals(options.Path.AsSpan(), StringComparison.Ordinal))
+      {
+         TraceLogger.LogServerError("WS Handshake: Server handshake failed: specified path does not match expected path.");
          await SendErrorResponseAsync(writer, "404 Not Found", "Specified path is not found.");
          return (null, null, null);
       }
@@ -103,50 +133,89 @@ public static class WsHandshake
       Dictionary<string, string>? requestHeaders = null;
       Dictionary<string, string>? requestCookies = null;
 
-      for (var i = 1; i < lines.Length; i++)
+      while (!remaining.IsEmpty)
       {
-         var line = lines[i];
+         var lineEnd = remaining.IndexOf("\r\n".AsSpan());
+         ReadOnlySpan<char> line;
+         if (lineEnd == -1)
+         {
+            line = remaining;
+            remaining = default;
+         }
+         else
+         {
+            line = remaining[..lineEnd];
+            remaining = remaining[(lineEnd + 2)..];
+         }
+
+         if (line.IsEmpty) continue;
+
          var colonIdx = line.IndexOf(':');
          if (colonIdx == -1) continue;
 
-         var headerName = line[..colonIdx].Trim().ToLowerInvariant();
-         var headerValue = line[(colonIdx + 1)..].Trim();
+         var headerNameSpan = line[..colonIdx].Trim();
+         var headerValueSpan = line[(colonIdx + 1)..].Trim();
 
          if (options.GatherHeaders)
          {
             requestHeaders ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            requestHeaders[line[..colonIdx].Trim()] = headerValue;
+            var lookup = requestHeaders.GetAlternateLookup<ReadOnlySpan<char>>();
+            lookup[headerNameSpan] = headerValueSpan.ToString();
          }
 
-         if (headerName == "upgrade" && headerValue.Equals("websocket", StringComparison.OrdinalIgnoreCase))
+         if (headerNameSpan.Equals("upgrade".AsSpan(), StringComparison.OrdinalIgnoreCase))
          {
-            isUpgrade = true;
+            if (headerValueSpan.Equals("websocket".AsSpan(), StringComparison.OrdinalIgnoreCase))
+            {
+               isUpgrade = true;
+            }
          }
-         else if (headerName == "connection" && headerValue.Contains("upgrade", StringComparison.OrdinalIgnoreCase))
+         else if (headerNameSpan.Equals("connection".AsSpan(), StringComparison.OrdinalIgnoreCase))
          {
-            isConnectionUpgrade = true;
+            if (headerValueSpan.Contains("upgrade".AsSpan(), StringComparison.OrdinalIgnoreCase))
+            {
+               isConnectionUpgrade = true;
+            }
          }
-         else if (headerName == "sec-websocket-key")
+         else if (headerNameSpan.Equals("sec-websocket-key".AsSpan(), StringComparison.OrdinalIgnoreCase))
          {
-            clientKey = headerValue;
+            clientKey = headerValueSpan.ToString();
          }
-         else if (headerName == "origin")
+         else if (headerNameSpan.Equals("origin".AsSpan(), StringComparison.OrdinalIgnoreCase))
          {
-            origin = headerValue;
+            origin = headerValueSpan.ToString();
          }
-         else if (headerName == "cookie" && options.GatherCookies)
+         else if (headerNameSpan.Equals("cookie".AsSpan(), StringComparison.OrdinalIgnoreCase) && options.GatherCookies)
          {
             requestCookies ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            var cookiePairs = headerValue.Split(';', StringSplitOptions.RemoveEmptyEntries);
+            var lookup = requestCookies.GetAlternateLookup<ReadOnlySpan<char>>();
 
-            foreach (var pair in cookiePairs)
+            var cookieRemaining = headerValueSpan;
+            while (!cookieRemaining.IsEmpty)
             {
-               var eqIdx = pair.IndexOf('=');
+               var semiIdx = cookieRemaining.IndexOf(';');
+               ReadOnlySpan<char> cookiePair;
+
+               if (semiIdx == -1)
+               {
+                  cookiePair = cookieRemaining;
+                  cookieRemaining = default;
+               }
+               else
+               {
+                  cookiePair = cookieRemaining[..semiIdx];
+                  cookieRemaining = cookieRemaining[(semiIdx + 1)..];
+               }
+
+               cookiePair = cookiePair.Trim();
+               if (cookiePair.IsEmpty) continue;
+
+               var eqIdx = cookiePair.IndexOf('=');
                if (eqIdx != -1)
                {
-                  var name = pair[..eqIdx].Trim();
-                  var value = pair[(eqIdx + 1)..].Trim();
-                  requestCookies[name] = value;
+                  var nameSpan = cookiePair[..eqIdx].Trim();
+                  var valueSpan = cookiePair[(eqIdx + 1)..].Trim();
+                  lookup[nameSpan] = valueSpan.ToString();
                }
             }
          }

--- a/Beskar.Networking.Transports.Ws/WsNetworkClient.cs
+++ b/Beskar.Networking.Transports.Ws/WsNetworkClient.cs
@@ -8,6 +8,8 @@ using Beskar.Networking.Transports.Tcp;
 using Beskar.Utilities.Tracing;
 using Beskar.Memory.Results;
 using Beskar.Networking.Abstractions.Enums;
+using System.Diagnostics;
+using Beskar.Networking.Abstractions.Telemetry;
 
 namespace Beskar.Networking.Transports.Ws;
 
@@ -50,6 +52,7 @@ public sealed class WsNetworkClient(WsTransportOptions options) : INetworkClient
       var connectResult = await _tcpClient.ConnectAsync(endPoint, ct);
       if (connectResult.Failed)
       {
+         TransportMetrics.RecordConnectionFailed(TransportKind.WebSocket, "TcpConnectionFailed");
          TraceLogger.LogClientError("WS ConnectAsync: Failed to establish TCP connection to {0}: {1}", endPoint, connectResult.Error.Message);
          return connectResult.Error;
       }
@@ -69,7 +72,28 @@ public sealed class WsNetworkClient(WsTransportOptions options) : INetworkClient
          }
 
          var tcpPipe = tcpStreamResult.Success.Transport;
-         var handshakeSuccess = await WsHandshake.ClientHandshakeAsync(tcpPipe, endPoint, _options, ct);
+
+         var start = Stopwatch.GetTimestamp();
+         var handshakeSuccess = false;
+         try
+         {
+            handshakeSuccess = await WsHandshake.ClientHandshakeAsync(tcpPipe, endPoint, _options, ct);
+            if (handshakeSuccess)
+            {
+               TransportMetrics.RecordWsHandshakeDuration(Stopwatch.GetElapsedTime(start).TotalMilliseconds);
+            }
+            else
+            {
+               TransportMetrics.RecordWsHandshakeFailure("HandshakeVerificationFailed");
+               TransportMetrics.RecordConnectionFailed(TransportKind.WebSocket, "HandshakeVerificationFailed");
+            }
+         }
+         catch (Exception ex)
+         {
+            TransportMetrics.RecordWsHandshakeFailure(ex.GetType().Name);
+            TransportMetrics.RecordConnectionFailed(TransportKind.WebSocket, ex.GetType().Name);
+            throw;
+         }
 
          if (!handshakeSuccess)
          {
@@ -95,6 +119,7 @@ public sealed class WsNetworkClient(WsTransportOptions options) : INetworkClient
       }
       catch (Exception ex)
       {
+         TransportMetrics.RecordConnectionFailed(TransportKind.WebSocket, ex.GetType().Name);
          TraceLogger.LogClientError("WS ConnectAsync: Unexpected error establishing WebSocket connection to {0}: {1}", endPoint, ex.Message);
          if (wsPipe is not null)
          {

--- a/Beskar.Networking.Transports.Ws/WsNetworkListener.cs
+++ b/Beskar.Networking.Transports.Ws/WsNetworkListener.cs
@@ -7,6 +7,8 @@ using Beskar.Networking.Transports.Tcp;
 using Beskar.Utilities.Tracing;
 using Beskar.Memory.Results;
 using Beskar.Networking.Abstractions.Enums;
+using System.Diagnostics;
+using Beskar.Networking.Abstractions.Telemetry;
 
 namespace Beskar.Networking.Transports.Ws;
 
@@ -68,6 +70,7 @@ public sealed class WsNetworkListener(EndPoint localAddress, WsTransportOptions 
 
       TraceLogger.LogServerInfo("WS Listener: Successfully bound and listening on {0}", LocalAddress);
       Interlocked.Increment(ref _binds);
+      TransportMetrics.RecordListenerStarted(TransportKind.WebSocket);
       return true;
    }
 
@@ -107,6 +110,7 @@ public sealed class WsNetworkListener(EndPoint localAddress, WsTransportOptions 
 
          TraceLogger.LogServerInfo("WS Listener: Successfully unbound from {0}", LocalAddress);
          Interlocked.Increment(ref _unbinds);
+         TransportMetrics.RecordListenerStopped(TransportKind.WebSocket);
          return true;
       }
       catch (Exception ex)
@@ -170,13 +174,38 @@ public sealed class WsNetworkListener(EndPoint localAddress, WsTransportOptions 
                   if (tcpStreamResult.Failed)
                   {
                      TraceLogger.LogServerError("WS Listener: Failed to accept TCP stream for handshake from {0}: {1}", tcpSession.RemoteAddress, tcpStreamResult.Error.Message);
+                     TransportMetrics.RecordConnectionFailed(TransportKind.WebSocket, "TcpStreamFailed");
                      await tcpSession.DisposeAsync();
                      return;
                   }
 
                   var tcpPipe = tcpStreamResult.Success.Transport;
-                  var (acceptKey, requestHeaders, requestCookies)
-                     = await WsHandshake.ServerHandshakeAsync(tcpPipe, _options, handshakeTimeoutCts.Token);
+                  
+                  var start = Stopwatch.GetTimestamp();
+                  string? acceptKey;
+                  Dictionary<string, string>? requestHeaders;
+                  Dictionary<string, string>? requestCookies;
+                  try
+                  {
+                     (acceptKey, requestHeaders, requestCookies)
+                        = await WsHandshake.ServerHandshakeAsync(tcpPipe, _options, handshakeTimeoutCts.Token);
+                     
+                     if (acceptKey != null)
+                     {
+                        TransportMetrics.RecordWsHandshakeDuration(Stopwatch.GetElapsedTime(start).TotalMilliseconds);
+                     }
+                     else
+                     {
+                        TransportMetrics.RecordWsHandshakeFailure("HandshakeFailed");
+                        TransportMetrics.RecordConnectionFailed(TransportKind.WebSocket, "HandshakeFailed");
+                     }
+                  }
+                  catch (Exception ex)
+                  {
+                     TransportMetrics.RecordWsHandshakeFailure(ex.GetType().Name);
+                     TransportMetrics.RecordConnectionFailed(TransportKind.WebSocket, ex.GetType().Name);
+                     throw;
+                  }
 
                   if (acceptKey == null)
                   {
@@ -205,6 +234,7 @@ public sealed class WsNetworkListener(EndPoint localAddress, WsTransportOptions 
                }
                catch (Exception ex)
                {
+                  TransportMetrics.RecordConnectionFailed(TransportKind.WebSocket, ex.GetType().Name);
                   TraceLogger.LogServerError("WS Listener: Unexpected exception during WebSocket handshake for client {0}: {1}", tcpSession.RemoteAddress, ex.Message);
                   if (wsSession != null)
                   {

--- a/Beskar.Networking.Transports.Ws/WsNetworkListener.cs
+++ b/Beskar.Networking.Transports.Ws/WsNetworkListener.cs
@@ -175,7 +175,8 @@ public sealed class WsNetworkListener(EndPoint localAddress, WsTransportOptions 
                   }
 
                   var tcpPipe = tcpStreamResult.Success.Transport;
-                  var acceptKey = await WsHandshake.ServerHandshakeAsync(tcpPipe, _options, handshakeTimeoutCts.Token);
+                  var (acceptKey, requestHeaders, requestCookies)
+                     = await WsHandshake.ServerHandshakeAsync(tcpPipe, _options, handshakeTimeoutCts.Token);
 
                   if (acceptKey == null)
                   {
@@ -185,9 +186,18 @@ public sealed class WsNetworkListener(EndPoint localAddress, WsTransportOptions 
                   }
 
                   var session = wsSession;
-                  var wsPipe = new WsDuplexPipe(tcpPipe, tcpSession, maskOutgoing: false, _options, () => session);
+                  var wsPipe = new WsDuplexPipe(tcpPipe, tcpSession, maskOutgoing: false, _options,
+                     () => session);
 
                   wsSession = new WsNetworkSession(tcpSession, wsPipe);
+                  if (requestHeaders is not null)
+                  {
+                     wsSession.Properties.Set("HttpRequestHeaders", requestHeaders);
+                  }
+                  if (requestCookies is not null)
+                  {
+                     wsSession.Properties.Set("HttpRequestCookies", requestCookies);
+                  }
 
                   TraceLogger.LogServerInfo("WS Listener: WebSocket server handshake successfully completed for client {0}. Enqueuing session {1}", tcpSession.RemoteAddress, wsSession.Id);
                   Interlocked.Increment(ref _sessionsAccepted);

--- a/Beskar.Networking.Transports.Ws/WsNetworkSession.cs
+++ b/Beskar.Networking.Transports.Ws/WsNetworkSession.cs
@@ -96,6 +96,11 @@ public sealed class WsNetworkSession : INetworkSession
 
    public ValueTask<Result<INetworkStream, NetworkCodeError>> AcceptStreamAsync(CancellationToken ct = default)
    {
+      if (Volatile.Read(ref _disposed) == 1)
+      {
+         throw new ObjectDisposedException(nameof(WsNetworkSession));
+      }
+
       TraceLogger.LogServerInfo("WS Session {0}: Instantiating WebSocket stream wrapper", Id);
       Interlocked.Increment(ref _streamsAccepted);
       return new ValueTask<Result<INetworkStream, NetworkCodeError>>(_stream);
@@ -105,6 +110,11 @@ public sealed class WsNetworkSession : INetworkSession
       NetworkStreamDirection direction = NetworkStreamDirection.Bidirectional,
       CancellationToken ct = default)
    {
+      if (Volatile.Read(ref _disposed) == 1)
+      {
+         throw new ObjectDisposedException(nameof(WsNetworkSession));
+      }
+
       TraceLogger.LogClientInfo("WS Session {0}: Opening WebSocket stream wrapper", Id);
       Interlocked.Increment(ref _streamsOpened);
       return new ValueTask<Result<INetworkStream, NetworkCodeError>>(_stream);

--- a/Beskar.Networking.Transports.Ws/WsTransportOptions.cs
+++ b/Beskar.Networking.Transports.Ws/WsTransportOptions.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Collections.Generic;
 using Beskar.Networking.Transports.Tcp;
 using Beskar.Networking.Transports.Ws.Enums;
 
@@ -59,6 +60,26 @@ public sealed class WsTransportOptions
    /// The Origin header to send during the client-side handshake.
    /// </summary>
    public string? Origin { get; set; }
+
+   /// <summary>
+   /// Custom HTTP headers to send during the client-side handshake upgrade request.
+   /// </summary>
+   public Dictionary<string, string>? Headers { get; set; }
+
+   /// <summary>
+   /// Custom cookies to send during the client-side handshake upgrade request.
+   /// </summary>
+   public Dictionary<string, string>? Cookies { get; set; }
+
+   /// <summary>
+   /// Whether the server should gather HTTP headers from the handshake request.
+   /// </summary>
+   public bool GatherHeaders { get; set; } = false;
+
+   /// <summary>
+   /// Whether the server should gather cookies from the handshake request.
+   /// </summary>
+   public bool GatherCookies { get; set; } = false;
 
    /// <summary>
    /// High-level frame-isolated message callback handler.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,9 +5,9 @@
       <ImplicitUsings>enable</ImplicitUsings>
       <Nullable>enable</Nullable>
 
-      <Version>3.1.1</Version>
-      <FileVersion>3.1.1</FileVersion>
-      <AssemblyVersion>3.0.0</AssemblyVersion>
+      <Version>10.0.0</Version>
+      <FileVersion>10.0.0</FileVersion>
+      <AssemblyVersion>10.0.0</AssemblyVersion>
    </PropertyGroup>
 
    <PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,11 +8,11 @@
     <PackageVersion Include="Beskar.Memory.Code.EnumGenerator" Version="1.7.3" />
     <PackageVersion Include="Beskar.Memory.Code.PacketGenerator" Version="1.7.3" />
     <PackageVersion Include="Beskar.Memory.Serialization" Version="1.7.3" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
-    <PackageVersion Include="TUnit" Version="1.64.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.400" />
+    <PackageVersion Include="TUnit" Version="1.65.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.16.0-preview.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0" />
     <PackageVersion Include="PolySharp" Version="1.16.0" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />

--- a/Documentation/Telemetry/Meters.md
+++ b/Documentation/Telemetry/Meters.md
@@ -57,3 +57,10 @@ Meter Name: `Beskar.Networking.Transport` (Version `1.0.0`)
 | `beskar.transport.memorypool.blocks.rented` | `Counter<long>` | `{block}` | Total number of memory pool block rent operations. |
 | `beskar.transport.memorypool.blocks.returned` | `Counter<long>` | `{block}` | Total number of memory pool block return operations. |
 | `beskar.transport.memorypool.blocks.active` | `UpDownCounter<long>` | `{block}` | Current count of active rented memory pool blocks. |
+| `beskar.transport.listeners.active` | `UpDownCounter<long>` | `{listener}` | Current count of active bound listener sockets. |
+| `beskar.transport.connections.failed` | `Counter<long>` | `{connection}` | Total failed connection or accept attempts. |
+| `beskar.transport.tls.handshake.duration` | `Histogram<double>` | `ms` | Duration of TLS handshakes in milliseconds. |
+| `beskar.transport.tls.handshake.failures` | `Counter<long>` | `{failure}` | Total failed TLS handshakes. |
+| `beskar.transport.ws.handshake.duration` | `Histogram<double>` | `ms` | Duration of WebSocket upgrade handshakes in milliseconds. |
+| `beskar.transport.ws.handshake.failures` | `Counter<long>` | `{failure}` | Total failed WebSocket upgrade handshakes. |
+| `beskar.transport.udp.packets.dropped` | `Counter<long>` | `{packet}` | Total number of UDP packets dropped due to full pipeline buffer. |

--- a/Experiments/Beskar.Networking.Transports.ChaosSimulator/Decorators.cs
+++ b/Experiments/Beskar.Networking.Transports.ChaosSimulator/Decorators.cs
@@ -11,6 +11,7 @@ using Beskar.Networking.Abstractions.Errors;
 using Beskar.Networking.Abstractions.Interfaces;
 using Beskar.Networking.Abstractions.Models;
 using Beskar.Networking.Abstractions.Threading;
+using Beskar.Networking.Abstractions.Telemetry;
 
 namespace Beskar.Networking.Transports.ChaosSimulator;
 
@@ -34,6 +35,7 @@ public sealed class ChaosNetworkClient(INetworkClient inner, ChaosOptions option
    {
       if (Random.Shared.NextDouble() < _options.ConnectFailureRate)
       {
+         TransportMetrics.RecordConnectionFailed(Transport, "ChaosDesignatedConnectFailure");
          return new NetworkCodeError(-100, "Chaos: Connection attempt failed by design.");
       }
 
@@ -172,6 +174,11 @@ public sealed class ChaosNetworkSession : INetworkSession
    public async ValueTask<Result<INetworkStream, NetworkCodeError>> AcceptStreamAsync(
       CancellationToken ct = default)
    {
+      if (Volatile.Read(ref _disposed) == 1)
+      {
+         throw new ObjectDisposedException(nameof(ChaosNetworkSession));
+      }
+
       using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, _sessionClosedCts.Token);
 
       if (Random.Shared.NextDouble() < _options.StreamOpenFailureRate)
@@ -206,6 +213,11 @@ public sealed class ChaosNetworkSession : INetworkSession
       NetworkStreamDirection direction = NetworkStreamDirection.Bidirectional,
       CancellationToken ct = default)
    {
+      if (Volatile.Read(ref _disposed) == 1)
+      {
+         throw new ObjectDisposedException(nameof(ChaosNetworkSession));
+      }
+
       using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, _sessionClosedCts.Token);
 
       // Simulate stream open failures/delays

--- a/Experiments/Beskar.Networking.Transports.ChaosSimulator/Program.cs
+++ b/Experiments/Beskar.Networking.Transports.ChaosSimulator/Program.cs
@@ -664,6 +664,14 @@ public static class Program
             var poolBlocksReturned = TelemetryCounters.GetValueOrDefault("beskar.transport.memorypool.blocks.returned", 0);
             var poolBlocksCreated = TelemetryCounters.GetValueOrDefault("beskar.transport.memorypool.blocks.created", 0);
 
+            var transportListenersActive = TelemetryGauges.GetValueOrDefault("beskar.transport.listeners.active", 0);
+            var transportConnectionsFailed = TelemetryCounters.GetValueOrDefault("beskar.transport.connections.failed", 0);
+            var transportTlsDuration = TelemetryGauges.GetValueOrDefault("beskar.transport.tls.handshake.duration", 0);
+            var transportTlsFailures = TelemetryCounters.GetValueOrDefault("beskar.transport.tls.handshake.failures", 0);
+            var transportWsDuration = TelemetryGauges.GetValueOrDefault("beskar.transport.ws.handshake.duration", 0);
+            var transportWsFailures = TelemetryCounters.GetValueOrDefault("beskar.transport.ws.handshake.failures", 0);
+            var transportUdpPacketsDropped = TelemetryCounters.GetValueOrDefault("beskar.transport.udp.packets.dropped", 0);
+
             ConsoleRender.CreateTable()
                .SetBorderColor(ConsoleColor.Magenta)
                .AddColumn("OpenTelemetry Meter", Alignment.Left, ConsoleColor.Magenta)
@@ -675,6 +683,11 @@ public static class Program
                .AddRow("Beskar.Networking.Transport", "beskar.transport.bytes.sent/received", "Counter By", $"Sent: {transportBytesSent:N0} B | Recv: {transportBytesRecv:N0} B")
                .AddRow("Beskar.Networking.Transport", "beskar.transport.memorypool.blocks.active", "UpDownCounter {block}", poolBlocksActive.ToString())
                .AddRow("Beskar.Networking.Transport", "beskar.transport.memorypool.blocks.rented/returned/created", "Counter {block}", $"Rented: {poolBlocksRented} | Returned: {poolBlocksReturned} | Created: {poolBlocksCreated}")
+               .AddRow("Beskar.Networking.Transport", "beskar.transport.listeners.active", "UpDownCounter {listener}", transportListenersActive.ToString())
+               .AddRow("Beskar.Networking.Transport", "beskar.transport.connections.failed", "Counter {connection}", transportConnectionsFailed.ToString())
+               .AddRow("Beskar.Networking.Transport", "beskar.transport.tls.handshake.duration/failures", "Histogram/Counter", $"Duration: {transportTlsDuration} ms | Failures: {transportTlsFailures}")
+               .AddRow("Beskar.Networking.Transport", "beskar.transport.ws.handshake.duration/failures", "Histogram/Counter", $"Duration: {transportWsDuration} ms | Failures: {transportWsFailures}")
+               .AddRow("Beskar.Networking.Transport", "beskar.transport.udp.packets.dropped", "Counter {packet}", transportUdpPacketsDropped.ToString())
                .Render();
          }
       }

--- a/Mqtt/Beskar.Mqtt.Server/Internal/MqttSessionRegistry.cs
+++ b/Mqtt/Beskar.Mqtt.Server/Internal/MqttSessionRegistry.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Beskar.Networking.Abstractions.Comparers;
+using Beskar.Networking.Abstractions.Extensions;
 
 namespace Beskar.Mqtt.Server.Internal;
 
@@ -70,11 +71,7 @@ public sealed class MqttSessionRegistry : IAsyncDisposable
 
    public async ValueTask DisposeAsync()
    {
-      foreach (var (_, value) in _sessions)
-      {
-         await value.DisposeAsync();
-      }
-
+      await _sessions.Values.DisposeAllAsync();
       _sessions.Clear();
    }
 }

--- a/Tests/Beskar.Networking.Transports.Common.Tests/DisposableExtensionsTests.cs
+++ b/Tests/Beskar.Networking.Transports.Common.Tests/DisposableExtensionsTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Beskar.Networking.Abstractions.Extensions;
+
+namespace Beskar.Networking.Transports.Common.Tests;
+
+public class DisposableExtensionsTests
+{
+   private class MockAsyncDisposable(Func<ValueTask>? onDispose = null) : IAsyncDisposable
+   {
+      public int DisposeCount { get; private set; }
+
+      public async ValueTask DisposeAsync()
+      {
+         DisposeCount++;
+         if (onDispose is not null)
+         {
+            await onDispose();
+         }
+      }
+   }
+
+   private class MockDisposable(Action? onDispose = null) : IDisposable
+   {
+      public int DisposeCount { get; private set; }
+
+      public void Dispose()
+      {
+         DisposeCount++;
+         onDispose?.Invoke();
+      }
+   }
+
+   [Test]
+   public async Task DisposeAllAsync_DisposesAllAsyncDisposables()
+   {
+      var mock1 = new MockAsyncDisposable();
+      var mock2 = new MockAsyncDisposable();
+      var list = new List<IAsyncDisposable> { mock1, mock2 };
+
+      await list.DisposeAllAsync();
+
+      await Assert.That(mock1.DisposeCount).IsEqualTo(1);
+      await Assert.That(mock2.DisposeCount).IsEqualTo(1);
+   }
+
+   [Test]
+   public async Task DisposeAllAsync_DisposesAllSyncDisposables()
+   {
+      var mock1 = new MockDisposable();
+      var mock2 = new MockDisposable();
+      var list = new List<IDisposable> { mock1, mock2 };
+
+      await list.DisposeAllAsync();
+
+      await Assert.That(mock1.DisposeCount).IsEqualTo(1);
+      await Assert.That(mock2.DisposeCount).IsEqualTo(1);
+   }
+
+   [Test]
+   public async Task DisposeAllAsync_DisposesMixedDisposables()
+   {
+      var mockAsync = new MockAsyncDisposable();
+      var mockSync = new MockDisposable();
+      var list = new List<object> { mockAsync, mockSync };
+
+      await list.DisposeAllAsync();
+
+      await Assert.That(mockAsync.DisposeCount).IsEqualTo(1);
+      await Assert.That(mockSync.DisposeCount).IsEqualTo(1);
+   }
+
+   [Test]
+   public async Task DisposeAllAsync_GracefullyHandlesNull()
+   {
+      List<IAsyncDisposable>? list = null;
+      await list.DisposeAllAsync();
+   }
+
+   [Test]
+   public async Task DisposeAllAsync_ContinuesDisposingEvenIfOneThrows()
+   {
+      var mock1 = new MockAsyncDisposable(() => throw new InvalidOperationException("Oops"));
+      var mock2 = new MockAsyncDisposable();
+      var list = new List<IAsyncDisposable> { mock1, mock2 };
+
+      await list.DisposeAllAsync();
+
+      await Assert.That(mock1.DisposeCount).IsEqualTo(1);
+      await Assert.That(mock2.DisposeCount).IsEqualTo(1);
+   }
+}

--- a/Tests/Beskar.Networking.Transports.Common.Tests/TelemetryTests.cs
+++ b/Tests/Beskar.Networking.Transports.Common.Tests/TelemetryTests.cs
@@ -189,4 +189,81 @@ public class TelemetryTests
       await Assert.That(recordedConnectedClients).IsEqualTo(1);
       await Assert.That(recordedSubscriptions).IsEqualTo(2);
    }
+
+   [Test]
+   public async Task TransportMetrics_RecordsNewDiagnosticInstrumentsCorrectly()
+   {
+      long recordedListenersActiveDelta = 0;
+      long recordedConnectionsFailed = 0;
+      long recordedTlsHandshakeFailures = 0;
+      long recordedWsHandshakeFailures = 0;
+      long recordedUdpPacketsDropped = 0;
+      double recordedTlsDuration = 0;
+      double recordedWsDuration = 0;
+
+      using var listener = new MeterListener();
+      listener.InstrumentPublished = (instrument, meterListener) =>
+      {
+         if (instrument.Meter.Name == TransportMetrics.MeterName)
+         {
+            meterListener.EnableMeasurementEvents(instrument);
+         }
+      };
+      listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, state) =>
+      {
+         if (instrument.Name == "beskar.transport.listeners.active")
+         {
+            Interlocked.Add(ref recordedListenersActiveDelta, measurement);
+         }
+         else if (instrument.Name == "beskar.transport.connections.failed")
+         {
+            Interlocked.Add(ref recordedConnectionsFailed, measurement);
+         }
+         else if (instrument.Name == "beskar.transport.tls.handshake.failures")
+         {
+            Interlocked.Add(ref recordedTlsHandshakeFailures, measurement);
+         }
+         else if (instrument.Name == "beskar.transport.ws.handshake.failures")
+         {
+            Interlocked.Add(ref recordedWsHandshakeFailures, measurement);
+         }
+         else if (instrument.Name == "beskar.transport.udp.packets.dropped")
+         {
+            Interlocked.Add(ref recordedUdpPacketsDropped, measurement);
+         }
+      });
+      listener.SetMeasurementEventCallback<double>((instrument, measurement, tags, state) =>
+      {
+         if (instrument.Name == "beskar.transport.tls.handshake.duration")
+         {
+            recordedTlsDuration = measurement;
+         }
+         else if (instrument.Name == "beskar.transport.ws.handshake.duration")
+         {
+            recordedWsDuration = measurement;
+         }
+      });
+      listener.Start();
+
+      // Act
+      TransportMetrics.RecordListenerStarted(TransportKind.Tcp);
+      TransportMetrics.RecordListenerStopped(TransportKind.Tcp);
+      TransportMetrics.RecordConnectionFailed(TransportKind.Tcp, "Refused");
+      TransportMetrics.RecordTlsHandshakeDuration(120.5);
+      TransportMetrics.RecordTlsHandshakeFailure("UntrustedCertificate");
+      TransportMetrics.RecordWsHandshakeDuration(45.2);
+      TransportMetrics.RecordWsHandshakeFailure("ForbiddenOrigin");
+      TransportMetrics.RecordUdpPacketDropped();
+
+      listener.RecordObservableInstruments();
+
+      // Assert
+      await Assert.That(recordedListenersActiveDelta).IsEqualTo(0); // +1 and then -1
+      await Assert.That(recordedConnectionsFailed).IsEqualTo(1);
+      await Assert.That(recordedTlsHandshakeFailures).IsEqualTo(1);
+      await Assert.That(recordedWsHandshakeFailures).IsEqualTo(1);
+      await Assert.That(recordedUdpPacketsDropped).IsEqualTo(1);
+      await Assert.That(recordedTlsDuration).IsEqualTo(120.5);
+      await Assert.That(recordedWsDuration).IsEqualTo(45.2);
+   }
 }

--- a/Tests/Beskar.Networking.Transports.Memory.Tests/MemoryTransportTests.cs
+++ b/Tests/Beskar.Networking.Transports.Memory.Tests/MemoryTransportTests.cs
@@ -7,6 +7,7 @@ using Beskar.Networking.Transports.Memory;
 
 namespace Beskar.Networking.Transports.Memory.Tests;
 
+[NotInParallel]
 public class MemoryTransportTests
 {
    [Test]

--- a/Tests/Beskar.Networking.Transports.NamedPipes.Tests/NamedPipeTransportTests.cs
+++ b/Tests/Beskar.Networking.Transports.NamedPipes.Tests/NamedPipeTransportTests.cs
@@ -8,6 +8,7 @@ using Beskar.Networking.Transports.NamedPipes.Extensions;
 
 namespace Beskar.Networking.Transports.NamedPipes.Tests;
 
+[NotInParallel]
 public class  NamedPipeTransportTests
 {
    private static string GetTempPipeName()

--- a/Tests/Beskar.Networking.Transports.Quic.Tests/QuicTransportTests.cs
+++ b/Tests/Beskar.Networking.Transports.Quic.Tests/QuicTransportTests.cs
@@ -9,6 +9,7 @@ using Beskar.Networking.Abstractions.Telemetry;
 
 namespace Beskar.Networking.Transports.Quic.Tests;
 
+[NotInParallel]
 public class QuicTransportTests
 {
 

--- a/Tests/Beskar.Networking.Transports.Tcp.Tests/TcpTransportTests.cs
+++ b/Tests/Beskar.Networking.Transports.Tcp.Tests/TcpTransportTests.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.Metrics;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
 using Beskar.Networking.Abstractions.Interfaces;
 using Beskar.Networking.Abstractions.Telemetry;
 using Beskar.Networking.Transports.Quic;
@@ -1027,6 +1028,102 @@ public class TcpTransportTests
 
       await clientSession.DisposeAsync();
       await serverSession.DisposeAsync();
+      await listener.UnbindAsync();
+   }
+
+   [Test]
+   public async Task TcpClientServer_TlsClientCertificateAuth_ValidatesClientCertificateSuccessfully()
+   {
+      using var serverCert = CertificateUtility.GenerateSelfSignedCertificate();
+      using var clientCert = CertificateUtility.GenerateSelfSignedCertificate();
+
+      var serverSslOptions = new SslServerAuthenticationOptions
+      {
+         ServerCertificate = serverCert
+      };
+
+      var clientSslOptionsWithCert = new SslClientAuthenticationOptions
+      {
+         TargetHost = "localhost",
+         RemoteCertificateValidationCallback = (sender, cert, chain, errors) => true,
+         ClientCertificates = new X509Certificate2Collection(clientCert)
+      };
+
+      var optionsWithClientCert = new TcpTransportOptions
+      {
+         UseSsl = true,
+         SslServerOptions = serverSslOptions,
+         SslClientOptions = clientSslOptionsWithCert,
+         ClientCertificateRequired = true,
+         ClientCertificateValidationCallback = (sender, cert, chain, errors) =>
+         {
+            return cert != null;
+         }
+      };
+
+      var listener = new TcpNetworkListener(new IPEndPoint(IPAddress.Loopback, 0), optionsWithClientCert);
+      var bindResult = await listener.BindAsync();
+      await Assert.That(bindResult.Failed).IsFalse();
+
+      // Test 1: Client provides certificate -> Connects and exchanges data successfully
+      var clientWithCert = new TcpNetworkClient(optionsWithClientCert);
+      var connectResult = await clientWithCert.ConnectAsync(listener.LocalAddress);
+      await Assert.That(connectResult.Failed).IsFalse();
+
+      var acceptResult = await listener.AcceptSessionAsync();
+      await Assert.That(acceptResult.Failed).IsFalse();
+
+      var clientSession = connectResult.Success!;
+      var serverSession = acceptResult.Success!;
+
+      var clientStream = (await clientSession.OpenStreamAsync()).Success!;
+      var serverStream = (await serverSession.AcceptStreamAsync()).Success!;
+      
+      var payload = "Secure Client Cert Message"u8.ToArray();
+      await clientStream.Transport.Output.WriteAsync(payload);
+      await clientStream.Transport.Output.FlushAsync();
+      
+      var readResult = await serverStream.Transport.Input.ReadAsync();
+      await Assert.That(readResult.Buffer.ToArray()).IsEquivalentTo(payload);
+      serverStream.Transport.Input.AdvanceTo(readResult.Buffer.End);
+
+      await clientSession.DisposeAsync();
+      await serverSession.DisposeAsync();
+
+      // Test 2: Client does NOT provide certificate -> Connection handshake fails
+      var clientSslOptionsNoCert = new SslClientAuthenticationOptions
+      {
+         TargetHost = "localhost",
+         RemoteCertificateValidationCallback = (sender, cert, chain, errors) => true
+      };
+
+      var optionsNoClientCert = new TcpTransportOptions
+      {
+         UseSsl = true,
+         SslServerOptions = new SslServerAuthenticationOptions { ServerCertificate = serverCert },
+         SslClientOptions = clientSslOptionsNoCert,
+         ClientCertificateRequired = true,
+         ClientCertificateValidationCallback = (sender, cert, chain, errors) =>
+         {
+            Console.WriteLine($"[DEBUG] NoCert Callback: cert is {(cert == null ? "null" : cert.Subject)}, errors: {errors}");
+            return cert != null;
+         }
+      };
+
+      var clientNoCert = new TcpNetworkClient(optionsNoClientCert);
+      var connectResult2 = await clientNoCert.ConnectAsync(listener.LocalAddress);
+      
+      // On the client, ConnectAsync may succeed initially due to TLS 1.3 pipelined handshakes,
+      // but the server's handshake task will fail and write a failed result to the session channel.
+      var acceptResult2 = await listener.AcceptSessionAsync();
+      await Assert.That(acceptResult2.Failed).IsTrue();
+
+      // Clean up the client session if it was established on the client side
+      if (!connectResult2.Failed)
+      {
+         await connectResult2.Success!.DisposeAsync();
+      }
+
       await listener.UnbindAsync();
    }
 }

--- a/Tests/Beskar.Networking.Transports.Tcp.Tests/TcpTransportTests.cs
+++ b/Tests/Beskar.Networking.Transports.Tcp.Tests/TcpTransportTests.cs
@@ -1126,5 +1126,35 @@ public class TcpTransportTests
 
       await listener.UnbindAsync();
    }
+
+   [Test]
+   public async Task TcpSession_ThrowsObjectDisposedException_AfterDisposed()
+   {
+      var options = new TcpTransportOptions();
+      var listener = new TcpNetworkListener(new IPEndPoint(IPAddress.Loopback, 0), options);
+      await listener.BindAsync();
+
+      var client = new TcpNetworkClient(options);
+      var connectResult = await client.ConnectAsync(listener.LocalAddress);
+      await Assert.That(connectResult.Failed).IsFalse();
+
+      var acceptResult = await listener.AcceptSessionAsync();
+      await Assert.That(acceptResult.Failed).IsFalse();
+
+      var clientSession = connectResult.Success!;
+      var serverSession = acceptResult.Success!;
+
+      // Dispose the sessions
+      await clientSession.DisposeAsync();
+      await serverSession.DisposeAsync();
+
+      // Subsequent AcceptStreamAsync/OpenStreamAsync calls should throw ObjectDisposedException
+      await Assert.ThrowsAsync<ObjectDisposedException>(async () => await clientSession.AcceptStreamAsync());
+      await Assert.ThrowsAsync<ObjectDisposedException>(async () => await clientSession.OpenStreamAsync());
+      await Assert.ThrowsAsync<ObjectDisposedException>(async () => await serverSession.AcceptStreamAsync());
+      await Assert.ThrowsAsync<ObjectDisposedException>(async () => await serverSession.OpenStreamAsync());
+
+      await listener.UnbindAsync();
+   }
 }
 

--- a/Tests/Beskar.Networking.Transports.Tcp.Tests/TcpTransportTests.cs
+++ b/Tests/Beskar.Networking.Transports.Tcp.Tests/TcpTransportTests.cs
@@ -1157,5 +1157,63 @@ public class TcpTransportTests
 
       await listener.UnbindAsync();
    }
+
+   [Test]
+   public async Task TcpClientServer_FailedTlsHandshake_IncrementsTlsFailuresMetrics()
+   {
+      long tlsFailures = 0;
+      using var meterListener = new MeterListener();
+      meterListener.InstrumentPublished = (instrument, listener) =>
+      {
+         if (instrument.Meter.Name == TransportMetrics.MeterName)
+         {
+            listener.EnableMeasurementEvents(instrument);
+         }
+      };
+      meterListener.SetMeasurementEventCallback<long>((instrument, measurement, tags, state) =>
+      {
+         if (instrument.Name == "beskar.transport.tls.handshake.failures")
+         {
+            Interlocked.Add(ref tlsFailures, measurement);
+         }
+      });
+      meterListener.Start();
+
+      using var certificate = CertificateUtility.GenerateSelfSignedCertificate();
+      var options = new TcpTransportOptions
+      {
+         UseSsl = true,
+         SslServerOptions = new SslServerAuthenticationOptions
+         {
+            ServerCertificate = certificate,
+            ClientCertificateRequired = false
+         },
+         SslClientOptions = new SslClientAuthenticationOptions
+         {
+            TargetHost = "localhost",
+            // Explicitly fail validation callback to cause TLS handshake failure
+            RemoteCertificateValidationCallback = (sender, cert, chain, errors) => false
+         }
+      };
+
+      var listener = new TcpNetworkListener(new IPEndPoint(IPAddress.Loopback, 0), options);
+      await listener.BindAsync();
+
+      var client = new TcpNetworkClient(options);
+      var connectResult = await client.ConnectAsync(listener.LocalAddress);
+      
+      // Connection should fail because TLS handshake fails
+      await Assert.That(connectResult.Failed).IsTrue();
+
+      // Wait briefly for server-side to handle the handshake exception
+      await Task.Delay(200);
+
+      // Verify that TLS handshake failures were recorded
+      var currentFailures = Volatile.Read(ref tlsFailures);
+      await Assert.That(currentFailures).IsGreaterThanOrEqualTo(1);
+
+      await client.DisposeAsync();
+      await listener.DisposeAsync();
+   }
 }
 

--- a/Tests/Beskar.Networking.Transports.Tcp.Tests/TcpTransportTests.cs
+++ b/Tests/Beskar.Networking.Transports.Tcp.Tests/TcpTransportTests.cs
@@ -10,6 +10,7 @@ using Beskar.Networking.Transports.Quic;
 
 namespace Beskar.Networking.Transports.Tcp.Tests;
 
+[NotInParallel]
 public class TcpTransportTests
 {
 

--- a/Tests/Beskar.Networking.Transports.Tcp.Tests/TcpTransportTests.cs
+++ b/Tests/Beskar.Networking.Transports.Tcp.Tests/TcpTransportTests.cs
@@ -963,5 +963,71 @@ public class TcpTransportTests
       await serverSession2.DisposeAsync();
       await listener.UnbindAsync();
    }
+
+   [Test]
+   public async Task TcpClientServer_KeepAliveOptionsConfigured_SucceedsAndAppliesToSockets()
+   {
+      var options = new TcpTransportOptions
+      {
+         KeepAlive = true,
+         KeepAliveTime = 3,
+         KeepAliveInterval = 1,
+         KeepAliveRetryCount = 2
+      };
+
+      // Test helper configuration directly
+      using (var testSocket = new Socket(SocketType.Stream, ProtocolType.Tcp))
+      {
+         options.ConfigureSocket(testSocket);
+         
+         var keepAliveOption = testSocket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive);
+         await Assert.That(keepAliveOption).IsNotNull();
+         await Assert.That((int)keepAliveOption!).IsNotEqualTo(0);
+         
+         var keepAliveTime = testSocket.GetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime);
+         await Assert.That(keepAliveTime).IsNotNull();
+         await Assert.That((int)keepAliveTime!).IsEqualTo(3);
+         
+         var keepAliveInterval = testSocket.GetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveInterval);
+         await Assert.That(keepAliveInterval).IsNotNull();
+         await Assert.That((int)keepAliveInterval!).IsEqualTo(1);
+         
+         var keepAliveRetryCount = testSocket.GetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveRetryCount);
+         await Assert.That(keepAliveRetryCount).IsNotNull();
+         await Assert.That((int)keepAliveRetryCount!).IsEqualTo(2);
+      }
+
+      // End-to-end data exchange test using keep-alive options
+      var listener = new TcpNetworkListener(new IPEndPoint(IPAddress.Loopback, 0), options);
+      var bindResult = await listener.BindAsync();
+      await Assert.That(bindResult.Failed).IsFalse();
+
+      var client = new TcpNetworkClient(options);
+      var connectResult = await client.ConnectAsync(listener.LocalAddress);
+      await Assert.That(connectResult.Failed).IsFalse();
+
+      var acceptResult = await listener.AcceptSessionAsync();
+      await Assert.That(acceptResult.Failed).IsFalse();
+
+      var clientSession = connectResult.Success!;
+      var serverSession = acceptResult.Success!;
+
+      var clientStream = (await clientSession.OpenStreamAsync()).Success!;
+      var serverStream = (await serverSession.AcceptStreamAsync()).Success!;
+
+      var payload = "Keep-alive message"u8.ToArray();
+      await clientStream.Transport.Output.WriteAsync(payload);
+      await clientStream.Transport.Output.FlushAsync();
+
+      var readResult = await serverStream.Transport.Input.ReadAsync();
+      var readBytes = readResult.Buffer.ToArray();
+      serverStream.Transport.Input.AdvanceTo(readResult.Buffer.End);
+
+      await Assert.That(readBytes).IsEquivalentTo(payload);
+
+      await clientSession.DisposeAsync();
+      await serverSession.DisposeAsync();
+      await listener.UnbindAsync();
+   }
 }
 

--- a/Tests/Beskar.Networking.Transports.Udp.Tests/UdpTransportTests.cs
+++ b/Tests/Beskar.Networking.Transports.Udp.Tests/UdpTransportTests.cs
@@ -10,6 +10,7 @@ using Beskar.Networking.Transports.Udp.Extensions;
 
 namespace Beskar.Networking.Transports.Udp.Tests;
 
+[NotInParallel]
 public class UdpTransportTests
 {
    [Test]

--- a/Tests/Beskar.Networking.Transports.Uds.Tests/UdsTransportTests.cs
+++ b/Tests/Beskar.Networking.Transports.Uds.Tests/UdsTransportTests.cs
@@ -10,6 +10,7 @@ using Beskar.Networking.Transports.Uds.Extensions;
 
 namespace Beskar.Networking.Transports.Uds.Tests;
 
+[NotInParallel]
 public class UdsTransportTests
 {
    private static string GetTempSocketPath()

--- a/Tests/Beskar.Networking.Transports.Ws.Tests/WsTransportTests.cs
+++ b/Tests/Beskar.Networking.Transports.Ws.Tests/WsTransportTests.cs
@@ -10,6 +10,7 @@ using Beskar.Networking.Transports.Tcp;
 
 namespace Beskar.Networking.Transports.Ws.Tests;
 
+[NotInParallel]
 public class WsTransportTests
 {
    [Test]
@@ -1400,6 +1401,56 @@ public class WsTransportTests
       await Assert.ThrowsAsync<ObjectDisposedException>(async () => await serverSession.OpenStreamAsync());
 
       await listener.UnbindAsync();
+   }
+
+   [Test]
+   public async Task WsClientServer_FailedWsHandshake_IncrementsWsFailuresMetrics()
+   {
+      long wsFailures = 0;
+      using var meterListener = new MeterListener();
+      meterListener.InstrumentPublished = (instrument, listener) =>
+      {
+         if (instrument.Meter.Name == TransportMetrics.MeterName)
+         {
+            listener.EnableMeasurementEvents(instrument);
+         }
+      };
+      meterListener.SetMeasurementEventCallback<long>((instrument, measurement, tags, state) =>
+      {
+         if (instrument.Name == "beskar.transport.ws.handshake.failures")
+         {
+            Interlocked.Add(ref wsFailures, measurement);
+         }
+      });
+      meterListener.Start();
+
+      var options = new WsTransportOptions();
+      var listener = new WsNetworkListener(new IPEndPoint(IPAddress.Loopback, 0), options);
+      await listener.BindAsync();
+
+      // Connect to WS listener using a standard TCP client and send a non-GET HTTP request to trigger server handshake failure
+      var tcpOptions = new TcpTransportOptions();
+      var tcpClient = new TcpNetworkClient(tcpOptions);
+      var connectResult = await tcpClient.ConnectAsync(listener.LocalAddress);
+      await Assert.That(connectResult.Failed).IsFalse();
+
+      var tcpSession = connectResult.Success!;
+      var tcpStream = (await tcpSession.OpenStreamAsync()).Success!;
+
+      // Send a POST request to trigger the server handshake failure
+      var invalidRequest = "POST / HTTP/1.1\r\nHost: localhost\r\n\r\n"u8.ToArray();
+      await tcpStream.Transport.Output.WriteAsync(invalidRequest);
+      await tcpStream.Transport.Output.FlushAsync();
+
+      // Wait briefly for server-side to reject the handshake and record the telemetry
+      await Task.Delay(200);
+
+      var currentFailures = Volatile.Read(ref wsFailures);
+      await Assert.That(currentFailures).IsGreaterThanOrEqualTo(1);
+
+      await tcpSession.DisposeAsync();
+      await tcpClient.DisposeAsync();
+      await listener.DisposeAsync();
    }
 }
 

--- a/Tests/Beskar.Networking.Transports.Ws.Tests/WsTransportTests.cs
+++ b/Tests/Beskar.Networking.Transports.Ws.Tests/WsTransportTests.cs
@@ -1270,5 +1270,108 @@ public class WsTransportTests
       var closedDelta = Volatile.Read(ref recordedConnectionsClosed) - initialClosed;
       await Assert.That(closedDelta).IsGreaterThanOrEqualTo(2);
    }
+
+   [Test]
+   public async Task WebSocketHandshake_CustomHeadersAndCookies_SentAndValidatedSuccessfully()
+   {
+      var serverOptions = new WsTransportOptions
+      {
+         Path = "/custom",
+         GatherHeaders = true,
+         GatherCookies = true
+      };
+
+      var clientOptions = new WsTransportOptions
+      {
+         Path = "/custom",
+         Headers = new Dictionary<string, string>
+         {
+            { "X-Custom-Auth", "SuperSecretToken" },
+            { "X-Requested-By", "ClientApp" }
+         },
+         Cookies = new Dictionary<string, string>
+         {
+            { "SessionId", "xyz987" },
+            { "UserRole", "Admin" }
+         }
+      };
+
+      var listener = new WsNetworkListener(new IPEndPoint(IPAddress.Loopback, 0), serverOptions);
+      var bindResult = await listener.BindAsync();
+      await Assert.That(bindResult.Failed).IsFalse();
+
+      var client = new WsNetworkClient(clientOptions);
+      var connectResult = await client.ConnectAsync(listener.LocalAddress);
+      await Assert.That(connectResult.Failed).IsFalse();
+
+      var acceptResult = await listener.AcceptSessionAsync();
+      await Assert.That(acceptResult.Failed).IsFalse();
+
+      var serverSession = acceptResult.Success!;
+      var clientSession = connectResult.Success!;
+
+      // Verify server session parsed and stored headers and cookies
+      await Assert.That(serverSession.Properties.TryGet<Dictionary<string, string>>("HttpRequestHeaders", out var headers)).IsTrue();
+      await Assert.That(headers).IsNotNull();
+      await Assert.That(headers!.ContainsKey("X-Custom-Auth")).IsTrue();
+      await Assert.That(headers["X-Custom-Auth"]).IsEqualTo("SuperSecretToken");
+      await Assert.That(headers.ContainsKey("X-Requested-By")).IsTrue();
+      await Assert.That(headers["X-Requested-By"]).IsEqualTo("ClientApp");
+
+      await Assert.That(serverSession.Properties.TryGet<Dictionary<string, string>>("HttpRequestCookies", out var cookies)).IsTrue();
+      await Assert.That(cookies).IsNotNull();
+      await Assert.That(cookies!.ContainsKey("SessionId")).IsTrue();
+      await Assert.That(cookies["SessionId"]).IsEqualTo("xyz987");
+      await Assert.That(cookies.ContainsKey("UserRole")).IsTrue();
+      await Assert.That(cookies["UserRole"]).IsEqualTo("Admin");
+
+      await clientSession.DisposeAsync();
+      await serverSession.DisposeAsync();
+      await listener.UnbindAsync();
+   }
+
+   [Test]
+   public async Task WebSocketHandshake_DefaultOptions_DoesNotGatherHeadersOrCookies()
+   {
+      var serverOptions = new WsTransportOptions
+      {
+         Path = "/default"
+      };
+
+      var clientOptions = new WsTransportOptions
+      {
+         Path = "/default",
+         Headers = new Dictionary<string, string>
+         {
+            { "X-Custom-Auth", "SuperSecretToken" }
+         },
+         Cookies = new Dictionary<string, string>
+         {
+            { "SessionId", "xyz987" }
+         }
+      };
+
+      var listener = new WsNetworkListener(new IPEndPoint(IPAddress.Loopback, 0), serverOptions);
+      var bindResult = await listener.BindAsync();
+      await Assert.That(bindResult.Failed).IsFalse();
+
+      var client = new WsNetworkClient(clientOptions);
+      var connectResult = await client.ConnectAsync(listener.LocalAddress);
+      await Assert.That(connectResult.Failed).IsFalse();
+
+      var acceptResult = await listener.AcceptSessionAsync();
+      await Assert.That(acceptResult.Failed).IsFalse();
+
+      var serverSession = acceptResult.Success!;
+      var clientSession = connectResult.Success!;
+
+      // Verify server session properties do not contain the keys
+      await Assert.That(serverSession.Properties.TryGet<Dictionary<string, string>>("HttpRequestHeaders", out _)).IsFalse();
+      await Assert.That(serverSession.Properties.TryGet<Dictionary<string, string>>("HttpRequestCookies", out _)).IsFalse();
+
+      await clientSession.DisposeAsync();
+      await serverSession.DisposeAsync();
+      await listener.UnbindAsync();
+   }
 }
 

--- a/Tests/Beskar.Networking.Transports.Ws.Tests/WsTransportTests.cs
+++ b/Tests/Beskar.Networking.Transports.Ws.Tests/WsTransportTests.cs
@@ -1369,8 +1369,36 @@ public class WsTransportTests
       await Assert.That(serverSession.Properties.TryGet<Dictionary<string, string>>("HttpRequestHeaders", out _)).IsFalse();
       await Assert.That(serverSession.Properties.TryGet<Dictionary<string, string>>("HttpRequestCookies", out _)).IsFalse();
 
+      await listener.UnbindAsync();
+   }
+
+   [Test]
+   public async Task WebSocketSession_ThrowsObjectDisposedException_AfterDisposed()
+   {
+      var options = new WsTransportOptions { Path = "/disposed" };
+      var listener = new WsNetworkListener(new IPEndPoint(IPAddress.Loopback, 0), options);
+      await listener.BindAsync();
+
+      var client = new WsNetworkClient(options);
+      var connectResult = await client.ConnectAsync(listener.LocalAddress);
+      await Assert.That(connectResult.Failed).IsFalse();
+
+      var acceptResult = await listener.AcceptSessionAsync();
+      await Assert.That(acceptResult.Failed).IsFalse();
+
+      var clientSession = connectResult.Success!;
+      var serverSession = acceptResult.Success!;
+
+      // Dispose the sessions
       await clientSession.DisposeAsync();
       await serverSession.DisposeAsync();
+
+      // Subsequent AcceptStreamAsync/OpenStreamAsync calls should throw ObjectDisposedException
+      await Assert.ThrowsAsync<ObjectDisposedException>(async () => await clientSession.AcceptStreamAsync());
+      await Assert.ThrowsAsync<ObjectDisposedException>(async () => await clientSession.OpenStreamAsync());
+      await Assert.ThrowsAsync<ObjectDisposedException>(async () => await serverSession.AcceptStreamAsync());
+      await Assert.ThrowsAsync<ObjectDisposedException>(async () => await serverSession.OpenStreamAsync());
+
       await listener.UnbindAsync();
    }
 }


### PR DESCRIPTION
- WebSockets now support custom HTTP Headers
- Added more open telemtry instruments
- Improved Websocket handshake with more spans
- Add more keep alive tcp socket options 
- Add tcp client side certificate options
- More disposed checks in the underlying transports
- DisposeAllAsync helper extension
- Added a bunch of new tests